### PR TITLE
#122: Move `gpg.homedir` to rultor descriptor

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -20,4 +20,4 @@ release:
   script: |
     mvn versions:set "-DnewVersion=$tag"
     git commit -am "$tag"
-    mvn -V -P qulice,github,ossrh -s ../settings.xml clean install
+    mvn -V -Dgpg.homedir=/home/r -P qulice,github,ossrh -s ../settings.xml clean install


### PR DESCRIPTION
#122 